### PR TITLE
Fix: unpack tarball in install directory

### DIFF
--- a/scripts/install-stone-cli.sh
+++ b/scripts/install-stone-cli.sh
@@ -16,7 +16,8 @@ done
 echo "Installing Stone in ${INSTALL_DIR}..."
 mkdir -p "${INSTALL_DIR}"
 wget https://github.com/Moonsong-Labs/stone-prover-cli/releases/download/${VERSION}/${TARBALL} -O "${INSTALL_DIR}/${TARBALL}"
-tar -xf "${INSTALL_DIR}/${TARBALL}"
+tar -xf "${INSTALL_DIR}/${TARBALL}" -C "${INSTALL_DIR}"
+rm "${INSTALL_DIR}/${TARBALL}"
 
 echo "Configuring permissions..."
 chmod +x "${INSTALL_DIR}/cpu_air_prover"


### PR DESCRIPTION
Problem: the install script fails because the commands are decompressed to the current working directory instead of the install directory.

Solution: specify the install directory to `tar`.