### PR TITLE
Feature: info logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1758,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3413,6 +3442,8 @@ version = "0.1.0"
 dependencies = [
  "cairo-vm",
  "clap 4.5.0",
+ "env_logger",
+ "log",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2021"
 [dependencies]
 cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "b2f69d230416129a84ad8237ccc13d088992f74b", features = ["extensive_hints"] }
 clap = { version = "4.5.0", features = ["derive"] }
+env_logger = { version = "0.11.2", features = ["color"] }
+log = "0.4.20"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.113" }
-stone-prover-sdk = { git = "https://github.com/Moonsong-Labs/stone-prover-sdk", tag="v0.3.0" }
+stone-prover-sdk = { git = "https://github.com/Moonsong-Labs/stone-prover-sdk", tag = "v0.3.0" }
 thiserror = { version = "1.0.57" }
 
 [dev-dependencies]

--- a/scripts/install-stone-cli.sh
+++ b/scripts/install-stone-cli.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-VERSION="v0.1.0"
+VERSION="v0.1.1"
 INSTALL_DIR="${HOME}/.stone/${VERSION}"
 TARBALL="stone-cli-linux-x86-64.tar.gz"
 

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,8 +1,13 @@
+use log::info;
 use stone_prover_sdk::error::VerifierError;
 use stone_prover_sdk::verifier::run_verifier;
 
 use crate::cli::VerifyArgs;
 
 pub fn verify(args: VerifyArgs) -> Result<(), VerifierError> {
-    run_verifier(args.proof_file.as_path())
+    info!("verification in progress...");
+    run_verifier(args.proof_file.as_path())?;
+    info!("verification completed!");
+
+    Ok(())
 }


### PR DESCRIPTION
Problem: the CLI does not display enough information about what it is doing.

Solution: add logs. The CLI now uses the `log` and `env_logger` crate to print messages. This will simplify the addition of a verbosity flag down the line.