### PR TITLE
Fix: remove --program-input from CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,9 +19,6 @@ pub struct ProveArgs {
     #[clap(long = "with-bootloader", default_value_t = false)]
     pub with_bootloader: bool,
 
-    #[clap(long = "program-input")]
-    pub program_input: Option<PathBuf>,
-
     #[clap(long = "layout")]
     pub layout: Option<Layout>,
 
@@ -41,20 +38,12 @@ pub struct ProveArgs {
 impl ProveArgs {
     pub fn command(mut self) -> ProveCommand {
         let mut cmd = Cli::command();
-        if self.with_bootloader {
-            if self.program_input.is_some() {
-                cmd.error(
-                    ErrorKind::ArgumentConflict,
-                    "Cannot load program input in bootloader mode",
-                )
-                .exit();
-            }
-        } else if self.programs.len() > 1 {
+        if !self.with_bootloader && self.programs.len() > 1 {
             cmd.error(
                 ErrorKind::ArgumentConflict,
                 "Cannot prove multiple programs without bootloader",
             )
-            .exit();
+                .exit();
         }
 
         let executable = match self.with_bootloader {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,7 @@ impl ProveArgs {
                 ErrorKind::ArgumentConflict,
                 "Cannot prove multiple programs without bootloader",
             )
-                .exit();
+            .exit();
         }
 
         let executable = match self.with_bootloader {


### PR DESCRIPTION
Problem: the program input is usually loaded through hints. These hints depend on each program and must be reimplemented for each program. As the CLI cannot load hints dynamically, this means that it is impossible to load program inputs in a generic way.

Solution: remove the option entirely. If you need to run a program with custom hints, use the Python VM `cairo-run` for now.