### PR TITLE
Feature: let user specify fact topologies path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "stone-prover-sdk"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/stone-prover-sdk?rev=4e86b70f245f02b8a76c7d7ad0ce93fe7f9a3400#4e86b70f245f02b8a76c7d7ad0ce93fe7f9a3400"
+source = "git+https://github.com/Moonsong-Labs/stone-prover-sdk?rev=9b310ed00fa66365900737847f9d57ece3e14ffe#9b310ed00fa66365900737847f9d57ece3e14ffe"
 dependencies = [
  "bincode",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stone-prover-cli"
 version = "0.1.0"
 edition = "2021"
- 
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = { version = "0.11.2", features = ["color"] }
 log = "0.4.20"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.113" }
-stone-prover-sdk = { git = "https://github.com/Moonsong-Labs/stone-prover-sdk", rev = "4e86b70f245f02b8a76c7d7ad0ce93fe7f9a3400" }
+stone-prover-sdk = { git = "https://github.com/Moonsong-Labs/stone-prover-sdk", rev = "9b310ed00fa66365900737847f9d57ece3e14ffe" }
 thiserror = { version = "1.0.57" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stone-prover-cli"
 version = "0.1.0"
 edition = "2021"
-
+ 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,14 +44,14 @@ impl ProveArgs {
                     ErrorKind::ArgumentConflict,
                     "Cannot specify fact topologies file in no-bootloader mode",
                 )
-                    .exit();
+                .exit();
             }
             if self.programs.len() > 1 {
                 cmd.error(
                     ErrorKind::ArgumentConflict,
                     "Cannot prove multiple programs in no-bootloader mode",
                 )
-                    .exit();
+                .exit();
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,12 +38,21 @@ pub struct ProveArgs {
 impl ProveArgs {
     pub fn command(mut self) -> ProveCommand {
         let mut cmd = Cli::command();
-        if !self.with_bootloader && self.programs.len() > 1 {
-            cmd.error(
-                ErrorKind::ArgumentConflict,
-                "Cannot prove multiple programs without bootloader",
-            )
-            .exit();
+        if !self.with_bootloader {
+            if self.config.fact_topologies_file.is_some() {
+                cmd.error(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot specify fact topologies file in no-bootloader mode",
+                )
+                    .exit();
+            }
+            if self.programs.len() > 1 {
+                cmd.error(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot prove multiple programs in no-bootloader mode",
+                )
+                    .exit();
+            }
         }
 
         let executable = match self.with_bootloader {
@@ -85,7 +94,9 @@ pub struct ConfigArgs {
     #[clap(long = "parameter-file")]
     pub parameter_file: Option<PathBuf>,
     #[clap(long = "output-file")]
-    output_file: Option<PathBuf>,
+    pub output_file: Option<PathBuf>,
+    #[clap(long = "fact-topologies-file")]
+    pub fact_topologies_file: Option<PathBuf>,
 }
 
 impl ConfigArgs {

--- a/src/commands/prove.rs
+++ b/src/commands/prove.rs
@@ -97,6 +97,7 @@ pub fn run_with_bootloader(
     executables: &[PathBuf],
     layout: Layout,
     allow_missing_builtins: bool,
+    fact_topologies_path: Option<PathBuf>,
 ) -> Result<ExecutionArtifacts, RunError> {
     let bootloader = Program::from_bytes(BOOTLOADER_PROGRAM, Some("main"))
         .map_err(RunError::FailedToLoadBootloader)?;
@@ -115,6 +116,7 @@ pub fn run_with_bootloader(
         tasks,
         Some(layout),
         Some(allow_missing_builtins),
+        fact_topologies_path,
     )
     .map_err(|e| e.into())
 }
@@ -143,9 +145,12 @@ pub fn prove(command: ProveCommand) -> Result<(), RunError> {
         Executable::BareMetal(program_path) => {
             run_program(program_path, command.layout, command.allow_missing_builtins)?
         }
-        Executable::WithBootloader(executables) => {
-            run_with_bootloader(&executables, command.layout, command.allow_missing_builtins)?
-        }
+        Executable::WithBootloader(executables) => run_with_bootloader(
+            &executables,
+            command.layout,
+            command.allow_missing_builtins,
+            command.config.fact_topologies_file,
+        )?,
     };
 
     let prover_parameters = user_prover_parameters.unwrap_or(generate_prover_parameters(


### PR DESCRIPTION
Problem: the user cannot specify the fact topologies file as output of the bootloader execution.

Solution: use the latest version of the SDK that supports this option and add a `--fact-topologies-file` option.