### PR TITLE
Feature: --bootloader-version flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::error::ErrorKind;
 use clap::{Args, CommandFactory, Parser};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use stone_prover_sdk::models::{Layout, Verifier};
 
 #[derive(Parser, Debug)]
@@ -12,12 +13,48 @@ pub enum Cli {
     Verify(VerifyArgs),
 }
 
+#[derive(Debug, Clone)]
+pub enum Bootloader {
+    V0_12_3,
+    V0_13_0,
+    Custom(PathBuf),
+}
+
+impl Bootloader {
+    pub fn latest() -> Self {
+        Self::V0_13_0
+    }
+    pub fn latest_compatible(verifier: &Verifier) -> Self {
+        match verifier {
+            Verifier::Stone => Self::latest(),
+            Verifier::L1 => Self::V0_12_3,
+        }
+    }
+}
+
+impl FromStr for Bootloader {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bootloader = match s {
+            "0.12.3" => Self::V0_12_3,
+            "0.13.0" => Self::V0_13_0,
+            path => Self::Custom(PathBuf::from(path)),
+        };
+
+        Ok(bootloader)
+    }
+}
+
 #[derive(Args, Debug)]
 #[command(args_conflicts_with_subcommands = true)]
 #[command(flatten_help = true)]
 pub struct ProveArgs {
     #[clap(long = "with-bootloader", default_value_t = false)]
     pub with_bootloader: bool,
+
+    #[clap(long = "bootloader-version")]
+    bootloader: Option<Bootloader>,
 
     #[clap(long = "layout")]
     pub layout: Option<Layout>,
@@ -44,23 +81,37 @@ impl ProveArgs {
                     ErrorKind::ArgumentConflict,
                     "Cannot specify fact topologies file in no-bootloader mode",
                 )
-                .exit();
+                    .exit();
+            }
+            if self.bootloader.is_some() {
+                cmd.error(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot specify bootloader version in no-bootloader mode",
+                )
+                    .exit();
             }
             if self.programs.len() > 1 {
                 cmd.error(
                     ErrorKind::ArgumentConflict,
                     "Cannot prove multiple programs in no-bootloader mode",
                 )
-                .exit();
+                    .exit();
             }
         }
 
-        let executable = match self.with_bootloader {
-            true => Executable::WithBootloader(self.programs),
-            false => Executable::BareMetal(self.programs.remove(0)),
-        };
         let layout = self.layout.unwrap_or(Layout::StarknetWithKeccak);
         let verifier = self.verifier.unwrap_or(Verifier::Stone);
+
+        let executable = match self.with_bootloader {
+            true => {
+                let bootloader = match self.bootloader {
+                    Some(version) => version,
+                    None => Bootloader::latest_compatible(&verifier),
+                };
+                Executable::WithBootloader(bootloader, self.programs)
+            }
+            false => Executable::BareMetal(self.programs.remove(0)),
+        };
 
         ProveCommand {
             executable,
@@ -84,7 +135,7 @@ pub struct ProveCommand {
 #[derive(Debug, Clone)]
 pub enum Executable {
     BareMetal(PathBuf),
-    WithBootloader(Vec<PathBuf>),
+    WithBootloader(Bootloader, Vec<PathBuf>),
 }
 
 #[derive(Args, Clone, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,21 +81,21 @@ impl ProveArgs {
                     ErrorKind::ArgumentConflict,
                     "Cannot specify fact topologies file in no-bootloader mode",
                 )
-                    .exit();
+                .exit();
             }
             if self.bootloader.is_some() {
                 cmd.error(
                     ErrorKind::ArgumentConflict,
                     "Cannot specify bootloader version in no-bootloader mode",
                 )
-                    .exit();
+                .exit();
             }
             if self.programs.len() > 1 {
                 cmd.error(
                     ErrorKind::ArgumentConflict,
                     "Cannot prove multiple programs in no-bootloader mode",
                 )
-                    .exit();
+                .exit();
             }
         }
 

--- a/src/commands/prove.rs
+++ b/src/commands/prove.rs
@@ -138,7 +138,7 @@ pub fn run_with_bootloader(
         Some(allow_missing_builtins),
         fact_topologies_path,
     )
-        .map_err(|e| e.into())
+    .map_err(|e| e.into())
 }
 
 pub fn prove(command: ProveCommand) -> Result<(), RunError> {

--- a/src/commands/prove.rs
+++ b/src/commands/prove.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -17,16 +18,35 @@ use stone_prover_sdk::fri::generate_prover_parameters;
 use stone_prover_sdk::models::{Layout, ProverConfig};
 use stone_prover_sdk::prover::run_prover;
 
-use crate::cli::{Executable, ProveCommand};
+use crate::cli::{Bootloader, Executable, ProveCommand};
 use crate::toolkit::json::{read_json_from_file, ReadJsonError};
 
-const BOOTLOADER_PROGRAM: &[u8] =
+const BOOTLOADER_V0_12_3: &[u8] =
+    include_bytes!("../../dependencies/cairo-programs/bootloader/bootloader-v0.12.3.json");
+
+const BOOTLOADER_V0_13_0: &[u8] =
     include_bytes!("../../dependencies/cairo-programs/bootloader/bootloader-v0.13.0.json");
 
 fn write_json_to_file<T: Serialize, P: AsRef<Path>>(obj: T, path: P) -> Result<(), std::io::Error> {
     let mut file = File::create(path)?;
     serde_json::to_writer(&mut file, &obj)?;
     Ok(())
+}
+
+fn load_bootloader(bootloader: Bootloader) -> Result<Program, RunError> {
+    let bootloader_bytes = match bootloader {
+        Bootloader::V0_12_3 => Cow::Borrowed(BOOTLOADER_V0_12_3),
+        Bootloader::V0_13_0 => Cow::Borrowed(BOOTLOADER_V0_13_0),
+        Bootloader::Custom(path) => {
+            let content = std::fs::read(&path).map_err(|e| RunError::Io(path, e))?;
+            Cow::Owned(content)
+        }
+    };
+
+    let bootloader_program = Program::from_bytes(bootloader_bytes.as_ref(), Some("main"))
+        .map_err(RunError::FailedToLoadBootloader)?;
+
+    Ok(bootloader_program)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -94,13 +114,13 @@ fn task_from_file(file: &Path) -> Result<TaskSpec, TaskError> {
 }
 
 pub fn run_with_bootloader(
+    bootloader: Bootloader,
     executables: &[PathBuf],
     layout: Layout,
     allow_missing_builtins: bool,
     fact_topologies_path: Option<PathBuf>,
 ) -> Result<ExecutionArtifacts, RunError> {
-    let bootloader = Program::from_bytes(BOOTLOADER_PROGRAM, Some("main"))
-        .map_err(RunError::FailedToLoadBootloader)?;
+    let bootloader_program = load_bootloader(bootloader)?;
     let tasks: Result<Vec<TaskSpec>, RunError> = executables
         .iter()
         .map(|path| {
@@ -112,13 +132,13 @@ pub fn run_with_bootloader(
         .collect();
     let tasks = tasks?;
     run_bootloader_in_proof_mode(
-        &bootloader,
+        &bootloader_program,
         tasks,
         Some(layout),
         Some(allow_missing_builtins),
         fact_topologies_path,
     )
-    .map_err(|e| e.into())
+        .map_err(|e| e.into())
 }
 
 pub fn prove(command: ProveCommand) -> Result<(), RunError> {
@@ -145,7 +165,8 @@ pub fn prove(command: ProveCommand) -> Result<(), RunError> {
         Executable::BareMetal(program_path) => {
             run_program(program_path, command.layout, command.allow_missing_builtins)?
         }
-        Executable::WithBootloader(executables) => run_with_bootloader(
+        Executable::WithBootloader(bootloader, executables) => run_with_bootloader(
+            bootloader,
             &executables,
             command.layout,
             command.allow_missing_builtins,


### PR DESCRIPTION
Problem: The bootloader version known by the L1 contract is different from the one we use (0.13.0). It would be convenient to be able to change the version of the bootloader / specify a custom one for testing.

Solution: Add a `--bootloader-version VERSION` flag. The `VERSION` value can be one of [`0.12.3`, `0.13.0`] or be the path to a compiled bootloader file.