### PR TITLE
Feature: `hash PROGRAM` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "starknet-crypto",
  "stone-prover-sdk",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = { version = "0.11.2", features = ["color"] }
 log = "0.4.20"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.113" }
+starknet-crypto = "0.6.1"
 stone-prover-sdk = { git = "https://github.com/Moonsong-Labs/stone-prover-sdk", rev = "9b310ed00fa66365900737847f9d57ece3e14ffe" }
 thiserror = { version = "1.0.57" }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use stone_prover_sdk::models::{Layout, Verifier};
 #[command(name = "stone")]
 #[command(bin_name = "stone")]
 pub enum Cli {
+    Hash(HashArgs),
     Prove(ProveArgs),
     Verify(VerifyArgs),
 }
@@ -44,6 +45,11 @@ impl FromStr for Bootloader {
 
         Ok(bootloader)
     }
+}
+
+#[derive(Args, Debug)]
+pub struct HashArgs {
+    pub program: PathBuf,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/hash.rs
+++ b/src/commands/hash.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+
+use cairo_vm::types::errors::cairo_pie_error::CairoPieError;
+use cairo_vm::types::errors::program_errors::ProgramError;
+use cairo_vm::types::program::Program;
+use cairo_vm::vm::runners::cairo_pie::{CairoPie, StrippedProgram};
+
+use crate::toolkit::program_hash::{compute_program_hash_chain, ProgramHashError};
+use crate::toolkit::zip::is_zip_file;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HashError {
+    #[error(transparent)]
+    CairoPie(#[from] CairoPieError),
+    #[error(transparent)]
+    Program(#[from] ProgramError),
+    #[error(transparent)]
+    ProgramHash(#[from] ProgramHashError),
+}
+
+fn stripped_program_from_file(file: &Path) -> Result<StrippedProgram, HashError> {
+    let stripped_program = if is_zip_file(file) {
+        let pie = CairoPie::from_file(file)?;
+        pie.metadata.program
+    } else {
+        let program = Program::from_file(file, Some("main"))?;
+        program.get_stripped_program()?
+    };
+
+    Ok(stripped_program)
+}
+
+pub fn hash(program_path: PathBuf) -> Result<(), HashError> {
+    let program = stripped_program_from_file(&program_path)?;
+    let bootloader_version = 0;
+
+    let program_hash = compute_program_hash_chain(&program, bootloader_version)?;
+    // Note that we use print here to avoid additional output and make the command
+    // usable in a script without parsing the output.
+    println!("{:#x}", program_hash);
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
+pub mod hash;
 pub mod prove;
 pub mod verify;
 
+pub use hash::hash;
 pub use prove::prove;
 pub use verify::verify;

--- a/src/commands/prove.rs
+++ b/src/commands/prove.rs
@@ -20,6 +20,7 @@ use stone_prover_sdk::prover::run_prover;
 
 use crate::cli::{Bootloader, Executable, ProveCommand};
 use crate::toolkit::json::{read_json_from_file, ReadJsonError};
+use crate::toolkit::zip::is_zip_file;
 
 const BOOTLOADER_V0_12_3: &[u8] =
     include_bytes!("../../dependencies/cairo-programs/bootloader/bootloader-v0.12.3.json");
@@ -83,13 +84,6 @@ pub fn run_program(
     let (runner, vm) = run_in_proof_mode(&program, layout, Some(allow_missing_builtins))
         .map_err(ExecutionError::RunFailed)?;
     extract_execution_artifacts(runner, vm).map_err(|e| e.into())
-}
-
-fn is_zip_file(file: &Path) -> bool {
-    match file.extension() {
-        Some(extension) => extension == "zip",
-        None => false,
-    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crate::cli::Cli;
+use crate::commands::hash::HashError;
 use crate::commands::prove::RunError;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use clap::Parser;
@@ -15,6 +16,8 @@ mod toolkit;
 
 #[derive(thiserror::Error, Debug)]
 enum CliError {
+    #[error(transparent)]
+    Hash(#[from] HashError),
     #[error(transparent)]
     Prove(#[from] RunError),
     #[error(transparent)]
@@ -40,6 +43,7 @@ fn setup_logging() {
 
 fn display_error(error: CliError) {
     let error_message = match error {
+        CliError::Hash(hash_error) => hash_error.to_string(),
         CliError::Prove(run_error) => match run_error {
             RunError::Io(path_buf, io_error) => {
                 format!("could not read {}: {io_error}.", path_buf.to_string_lossy())
@@ -95,6 +99,7 @@ fn display_error(error: CliError) {
 
 fn process_cli_command(command: Cli) -> Result<(), CliError> {
     match command {
+        Cli::Hash(hash_args) => commands::hash(hash_args.program)?,
         Cli::Prove(prove_args) => commands::prove(prove_args.command())?,
         Cli::Verify(verify_args) => commands::verify(verify_args)?,
     };

--- a/src/toolkit/mod.rs
+++ b/src/toolkit/mod.rs
@@ -1,1 +1,3 @@
 pub mod json;
+pub mod program_hash;
+pub mod zip;

--- a/src/toolkit/program_hash.rs
+++ b/src/toolkit/program_hash.rs
@@ -1,0 +1,144 @@
+// TODO: replace by the `cairo-vm` implementation once
+//       https://github.com/lambdaclass/cairo-vm/pull/1647 is merged.
+
+use cairo_vm::serde::deserialize_program::BuiltinName;
+use cairo_vm::types::relocatable::MaybeRelocatable;
+use cairo_vm::vm::runners::cairo_pie::StrippedProgram;
+use cairo_vm::Felt252;
+use starknet_crypto::{pedersen_hash, FieldElement};
+
+type HashFunction = fn(&FieldElement, &FieldElement) -> FieldElement;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HashChainError {
+    #[error("Data array must contain at least one element.")]
+    EmptyData,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ProgramHashError {
+    #[error(transparent)]
+    HashChain(#[from] HashChainError),
+
+    #[error(
+    "Invalid program builtin: builtin name too long to be converted to field element: {0}"
+    )]
+    InvalidProgramBuiltin(&'static str),
+
+    #[error("Invalid program data: data contains relocatable(s)")]
+    InvalidProgramData,
+
+    /// Conversion from Felt252 to FieldElement failed. This is unlikely to happen
+    /// unless the implementation of Felt252 changes and this code is not updated properly.
+    #[error("Conversion from Felt252 to FieldElement failed")]
+    Felt252ToFieldElementConversionFailed,
+}
+
+/// Computes a hash chain over the data, in the following order:
+///     h(data[0], h(data[1], h(..., h(data[n-2], data[n-1])))).
+///
+/// Reimplements this Python function:
+/// def compute_hash_chain(data, hash_func=pedersen_hash):
+///     assert len(data) >= 1, f"len(data) for hash chain computation must be >= 1; got: {len(data)}."
+///     return functools.reduce(lambda x, y: hash_func(y, x), data[::-1])
+fn compute_hash_chain<'a, I>(
+    data: I,
+    hash_func: HashFunction,
+) -> Result<FieldElement, HashChainError>
+    where
+        I: Iterator<Item=&'a FieldElement> + DoubleEndedIterator,
+{
+    match data.copied().rev().reduce(|x, y| hash_func(&y, &x)) {
+        Some(result) => Ok(result),
+        None => Err(HashChainError::EmptyData),
+    }
+}
+
+/// Creates an instance of `FieldElement` from a builtin name.
+///
+/// Converts the builtin name to bytes then attempts to create a field element from
+/// these bytes. This function will fail if the builtin name is over 31 characters.
+fn builtin_to_field_element(builtin: &BuiltinName) -> Result<FieldElement, ProgramHashError> {
+    // The Python implementation uses the builtin name without suffix
+    let builtin_name = builtin
+        .name()
+        .strip_suffix("_builtin")
+        .unwrap_or(builtin.name());
+
+    FieldElement::from_byte_slice_be(builtin_name.as_bytes())
+        .map_err(|_| ProgramHashError::InvalidProgramBuiltin(builtin.name()))
+}
+
+/// The `value: FieldElement` is `pub(crate)` and there is no accessor.
+/// This function converts a `Felt252` to a `FieldElement` using a safe, albeit inefficient,
+/// method.
+fn felt_to_field_element(felt: &Felt252) -> Result<FieldElement, ProgramHashError> {
+    let bytes = felt.to_bytes_be();
+    FieldElement::from_bytes_be(&bytes)
+        .map_err(|_e| ProgramHashError::Felt252ToFieldElementConversionFailed)
+}
+
+/// Converts a `MaybeRelocatable` into a `FieldElement` value.
+///
+/// Returns `InvalidProgramData` if `maybe_relocatable` is not an integer
+fn maybe_relocatable_to_field_element(
+    maybe_relocatable: &MaybeRelocatable,
+) -> Result<FieldElement, ProgramHashError> {
+    let felt = maybe_relocatable
+        .get_int_ref()
+        .ok_or(ProgramHashError::InvalidProgramData)?;
+    felt_to_field_element(felt)
+}
+
+/// Computes the Pedersen hash of a program.
+///
+/// Reimplements this Python function:
+/// def compute_program_hash_chain(program: ProgramBase, bootloader_version=0):
+///     builtin_list = [from_bytes(builtin.encode("ascii")) for builtin in program.builtins]
+///     # The program header below is missing the data length, which is later added to the data_chain.
+///     program_header = [bootloader_version, program.main, len(program.builtins)] + builtin_list
+///     data_chain = program_header + program.data
+///
+///     return compute_hash_chain([len(data_chain)] + data_chain)
+pub fn compute_program_hash_chain(
+    program: &StrippedProgram,
+    bootloader_version: usize,
+) -> Result<FieldElement, ProgramHashError> {
+    let program_main = program.main;
+    let program_main = FieldElement::from(program_main);
+
+    // Convert builtin names to field elements
+    let builtin_list: Result<Vec<FieldElement>, _> = program
+        .builtins
+        .iter()
+        .map(builtin_to_field_element)
+        .collect();
+    let builtin_list = builtin_list?;
+
+    let program_header = vec![
+        FieldElement::from(bootloader_version),
+        program_main,
+        FieldElement::from(program.builtins.len()),
+    ];
+
+    let program_data: Result<Vec<_>, _> = program
+        .data
+        .iter()
+        .map(maybe_relocatable_to_field_element)
+        .collect();
+    let program_data = program_data?;
+
+    let data_chain_len = program_header.len() + builtin_list.len() + program_data.len();
+    let data_chain_len_vec = vec![FieldElement::from(data_chain_len)];
+
+    // Prepare a chain of iterators to feed to the hash function
+    let data_chain = [
+        &data_chain_len_vec,
+        &program_header,
+        &builtin_list,
+        &program_data,
+    ];
+
+    let hash = compute_hash_chain(data_chain.iter().flat_map(|&v| v.iter()), pedersen_hash)?;
+    Ok(hash)
+}

--- a/src/toolkit/zip.rs
+++ b/src/toolkit/zip.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+pub fn is_zip_file(file: &Path) -> bool {
+    match file.extension() {
+        Some(extension) => extension == "zip",
+        None => false,
+    }
+}

--- a/tests/test_hash.rs
+++ b/tests/test_hash.rs
@@ -1,0 +1,32 @@
+use crate::common::cli_in_path;
+use rstest::rstest;
+use std::path::Path;
+
+mod common;
+
+// "0x3106b7628a3cbddadb733ea96284977cc21e890d61aa6dee00badcbd90065ce"
+
+fn invoke_cli(program_file: &Path) -> Result<std::process::Output, std::io::Error> {
+    let mut command = std::process::Command::new("stone-prover-cli");
+    command.arg("hash").arg(program_file);
+
+    command.output()
+}
+
+#[rstest]
+fn test_hash_bootloader(#[from(cli_in_path)] _path: ()) {
+    let expected_hash = "0x3106b7628a3cbddadb733ea96284977cc21e890d61aa6dee00badcbd90065ce";
+
+    let program_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("dependencies/cairo-programs/bootloader/bootloader-v0.13.0.json");
+
+    let output = invoke_cli(program_file.as_path()).expect("Command should succeed");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let hash = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(hash.trim(), expected_hash);
+}


### PR DESCRIPTION
Problem: It is useful to be able to compute the hash of a program to check its integrity.

Solution: add a `hash` command based on a port of the implementation of `cairo-hash-program` in `cairo-lang`.